### PR TITLE
remove python2 package build support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,16 +3,10 @@ Maintainer: CAIDA Software Maintainer <software@caida.org>
 Section: python
 Priority: optional
 Build-Depends: dh-python, debhelper (>= 9),
-  python-setuptools, python3-setuptools, python-all-dev, python3-all-dev,
-  python-confluent-kafka, python3-confluent-kafka, libtimeseries0-dev
+  python3-setuptools, python3-all-dev,
+  python3-confluent-kafka, libtimeseries0-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/CAIDA/pytimeseries
-
-Package: python-pytimeseries
-Architecture: any
-Depends: ${misc:Depends}, ${python:Depends}, ${shlibs:Depends}
-Description: Python interface to libTimeSeries
- Provides a Python interface to write data to time series DBs.
 
 Package: python3-pytimeseries
 Architecture: any


### PR DESCRIPTION
This allows our build system to avoid hacky tricks to backport multiple dependent python2 package that no-longer exists in current lts operating systems (e.g. ubuntu 20.04 and further).