### PR TITLE
Don't set "--with python2" when building packages.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@
 # Tue, 13 Aug 2019 13:42:49 -0700
 export PYBUILD_NAME=pytimeseries
 %:
-	dh $@ --with python2,python3 --buildsystem=pybuild
+	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_auto_install:
 	dh_auto_install


### PR DESCRIPTION
Modern Debian/Ubuntu releases no longer have python2 support, so can't build packages using `--with python2`.